### PR TITLE
Untitled

### DIFF
--- a/pip2arch.py
+++ b/pip2arch.py
@@ -37,7 +37,11 @@ class Package(object):
     def get_package(self, name, outname, version=None):
         if version is None:
             versions = self.client.package_releases(name)
-            version = self.choose_version(versions)
+            if len(versions) > 1:
+                version = self.choose_version(versions)
+            else:
+                logging.info('Using version %s' % versions[0])
+                version = versions[0]
         self.version = version
         
         self.outname = outname


### PR DESCRIPTION
The commits are pretty easy to understand:
- SHA: 98bdd72fbe867f54e19185848ff105642eb64aa4
  uses pkg.pyversion in the PKGBUILD instead of the hardcoded python2
- SHA: 40194a2faa5ce9479d1ff9178b8f45fd1b81c3b1 first checks if there are multiple versions of the package and only then asks the user to choose one
