### PR TITLE
Interactive (search) improvements etc

### DIFF
--- a/pip2arch.py
+++ b/pip2arch.py
@@ -167,8 +167,6 @@ def main():
                         help="Search for given package name, instead of building PKGBUILD")
     parser.add_argument('-i', '--interactive', dest='interactive', action='store_true',
                         help="Makes all commands interactive, prompting user for input.")
-    parser.add_argument('--search-build', dest='searchbuild', action='store_true',
-                        help='Search for given package name, and build PKGBUILD for it')
     parser.add_argument('-d', '--dependencies', dest='depends', action='append',
                         help="The name of a package that should be added to the depends array")
     parser.add_argument('-m', '--make-dependencies', dest='makedepends', action='append',


### PR DESCRIPTION
I. I removed --build--search and replaced it with a -i/--interactive switch. I think this is good because instead of having two separate search commands, you can just add an interactive switch to toggle interactive searches on. Also, it allows the possibility for you to enable/disable the interactivity of other commands instead of polluting the list of available commands. It can be used as follows:

pip2arch.py --interactive --search <term>
pip2arch.py -i -s <term>
pip2arch.py -is <term>

II. Previously, when pip2arch exited prematurely due to an error, a blank PKGBUILD file is created. This is no longer the case. 

III. Rather minor, but now there isn't an extra line above the PKGBUILD.

Question, is there a reason you name everything Pipy instead of Pypi is it is rightfully called? Correct me if I am wrong.

Aspidites
aka EnvoyRising
