### PR TITLE
fixed protocol error by changing to https

### DIFF
--- a/pip2arch.py
+++ b/pip2arch.py
@@ -50,7 +50,7 @@ class LackOfInformation(pip2archException): pass
 
 class Package(object):
     logging.info('Creating Server Proxy object')
-    client = ServerProxy('http://pypi.python.org/pypi')
+    client = ServerProxy('https://pypi.python.org/pypi')
     depends = []
     makedepends = []
     data_received = False


### PR DESCRIPTION
Because the script is using http by default, it fails to search and find info about the packages.

Changing the link to https fixed this issue.