### PR TITLE
Throw exeption if pypi package does not exist.

### DIFF
--- a/pip2arch.py
+++ b/pip2arch.py
@@ -59,6 +59,8 @@ class Package(object):
     def get_package(self, name, outname, pyversion ,version=None):
         if version is None:
             versions = self.client.package_releases(name)
+            if len(versions) == 0:
+                raise ValueError(f"Could not find package `{name}`.")
             if len(versions) > 1:
                 version = self.choose_version(versions)
             else:


### PR DESCRIPTION
Without this patch it only says `IndexError: list index out of range` and the user doesn't know what python mean. This exeption says: `ValueError: Could not find package "doesnt_exist".`